### PR TITLE
feat: log script output to `stdout`/`stderr` passed by semantic-release core

### DIFF
--- a/lib/exec-script.js
+++ b/lib/exec-script.js
@@ -1,14 +1,14 @@
 const {template} = require('lodash');
 const execa = require('execa');
 
-module.exports = async ({cmd, ...config}, {cwd, env, logger, ...context}) => {
+module.exports = async ({cmd, ...config}, {cwd, env, stdout, stderr, logger, ...context}) => {
   const script = template(cmd)({config, ...context});
 
   logger.log('Call script %s', script);
 
   const shell = execa.shell(script, {cwd, env});
-  shell.stdout.pipe(process.stdout);
-  shell.stderr.pipe(process.stderr);
+  shell.stdout.pipe(stdout);
+  shell.stderr.pipe(stderr);
 
   return (await shell).stdout.trim();
 };

--- a/package.json
+++ b/package.json
@@ -30,6 +30,7 @@
     "nyc": "^12.0.1",
     "semantic-release": "^15.0.0",
     "sinon": "^6.0.0",
+    "stream-buffers": "^3.0.2",
     "xo": "^0.21.0"
   },
   "engines": {
@@ -64,7 +65,7 @@
     "all": true
   },
   "peerDependencies": {
-    "semantic-release": ">=13.0.0 <16.0.0"
+    "semantic-release": ">=15.9.0 <16.0.0"
   },
   "prettier": {
     "printWidth": 120,

--- a/test/analyze-commits.test.js
+++ b/test/analyze-commits.test.js
@@ -1,12 +1,11 @@
 import test from 'ava';
 import {stub} from 'sinon';
+import {WritableStreamBuffer} from 'stream-buffers';
 import {analyzeCommits} from '..';
 
-// Disable logs during tests
-stub(process.stdout, 'write');
-stub(process.stderr, 'write');
-
 test.beforeEach(t => {
+  t.context.stdout = new WritableStreamBuffer();
+  t.context.stderr = new WritableStreamBuffer();
   // Mock logger
   t.context.log = stub();
   t.context.error = stub();
@@ -17,7 +16,7 @@ test('Return the value analyzeCommits script wrote to stdout', async t => {
   const pluginConfig = {
     cmd: './test/fixtures/echo-args.sh "minor   "',
   };
-  const context = {logger: t.context.logger};
+  const context = {stdout: t.context.stdout, stderr: t.context.stderr, logger: t.context.logger};
 
   const result = await analyzeCommits(pluginConfig, context);
   t.is(result, 'minor');
@@ -27,7 +26,7 @@ test('Return "undefined" if the analyzeCommits script wrtite nothing to stdout',
   const pluginConfig = {
     cmd: './test/fixtures/echo-args.sh "   "',
   };
-  const context = {logger: t.context.logger};
+  const context = {stdout: t.context.stdout, stderr: t.context.stderr, logger: t.context.logger};
 
   const result = await analyzeCommits(pluginConfig, context);
   t.is(result, undefined);
@@ -35,7 +34,7 @@ test('Return "undefined" if the analyzeCommits script wrtite nothing to stdout',
 
 test('Throw Error if if the analyzeCommits script does not returns 0', async t => {
   const pluginConfig = {cmd: 'exit 1'};
-  const context = {logger: t.context.logger};
+  const context = {stdout: t.context.stdout, stderr: t.context.stderr, logger: t.context.logger};
 
   await t.throws(analyzeCommits(pluginConfig, context), Error);
 });

--- a/test/exec-script.test.js
+++ b/test/exec-script.test.js
@@ -1,36 +1,36 @@
 import test from 'ava';
 import {stub} from 'sinon';
+import {WritableStreamBuffer} from 'stream-buffers';
 import execScript from '../lib/exec-script';
 
 test.beforeEach(t => {
+  t.context.stdout = new WritableStreamBuffer();
+  t.context.stderr = new WritableStreamBuffer();
   // Mock logger
   t.context.log = stub();
   t.context.error = stub();
   t.context.logger = {log: t.context.log, error: t.context.error};
-  t.context.stdout = stub(process.stdout, 'write');
-  t.context.stderr = stub(process.stderr, 'write');
-});
-
-test.afterEach.always(t => {
-  // Restore the logs
-  t.context.stdout.restore();
-  t.context.stderr.restore();
 });
 
 test.serial('Pipe script output to stdout and stderr', async t => {
   const pluginConfig = {cmd: '>&2 echo "write to stderr" && echo "write to stdout"'};
-  const context = {logger: t.context.logger, options: {}};
+  const context = {stdout: t.context.stdout, stderr: t.context.stderr, logger: t.context.logger, options: {}};
 
   const result = await execScript(pluginConfig, context);
 
   t.is(result, 'write to stdout');
-  t.is(t.context.stdout.args[0][0].toString().trim(), 'write to stdout');
-  t.is(t.context.stderr.args[0][0].toString().trim(), 'write to stderr');
+  t.is(t.context.stdout.getContentsAsString('utf8').trim(), 'write to stdout');
+  t.is(t.context.stderr.getContentsAsString('utf8').trim(), 'write to stderr');
 });
 
 test.serial('Generate command with template', async t => {
   const pluginConfig = {cmd: `./test/fixtures/echo-args.sh \${config.conf} \${lastRelease.version}`, conf: 'confValue'};
-  const context = {lastRelease: {version: '1.0.0'}, logger: t.context.logger};
+  const context = {
+    stdout: t.context.stdout,
+    stderr: t.context.stderr,
+    lastRelease: {version: '1.0.0'},
+    logger: t.context.logger,
+  };
 
   const result = await execScript(pluginConfig, context);
   t.is(result, 'confValue 1.0.0');

--- a/test/fail.test.js
+++ b/test/fail.test.js
@@ -1,11 +1,11 @@
 import test from 'ava';
 import {stub} from 'sinon';
+import {WritableStreamBuffer} from 'stream-buffers';
 import {fail} from '..';
 
-stub(process.stdout, 'write');
-stub(process.stderr, 'write');
-
 test.beforeEach(t => {
+  t.context.stdout = new WritableStreamBuffer();
+  t.context.stderr = new WritableStreamBuffer();
   // Mock logger
   t.context.log = stub();
   t.context.error = stub();
@@ -14,14 +14,14 @@ test.beforeEach(t => {
 
 test('Execute script in fail step', async t => {
   const pluginConfig = {cmd: './test/fixtures/echo-args.sh'};
-  const context = {logger: t.context.logger};
+  const context = {stdout: t.context.stdout, stderr: t.context.stderr, logger: t.context.logger};
 
   await t.notThrows(fail(pluginConfig, context));
 });
 
 test('Throw "Error" if the fail script does not returns 0', async t => {
   const pluginConfig = {cmd: 'exit 1'};
-  const context = {logger: t.context.logger};
+  const context = {stdout: t.context.stdout, stderr: t.context.stderr, logger: t.context.logger};
 
   await t.throws(fail(pluginConfig, context), Error);
 });

--- a/test/generate-notes.test.js
+++ b/test/generate-notes.test.js
@@ -1,11 +1,11 @@
 import test from 'ava';
 import {stub} from 'sinon';
+import {WritableStreamBuffer} from 'stream-buffers';
 import {generateNotes} from '..';
 
-stub(process.stdout, 'write');
-stub(process.stderr, 'write');
-
 test.beforeEach(t => {
+  t.context.stdout = new WritableStreamBuffer();
+  t.context.stderr = new WritableStreamBuffer();
   // Mock logger
   t.context.log = stub();
   t.context.error = stub();
@@ -16,7 +16,7 @@ test('Return the value generateNotes script wrote to stdout', async t => {
   const pluginConfig = {
     cmd: './test/fixtures/echo-args.sh "\nRelease note \n\n"',
   };
-  const context = {logger: t.context.logger};
+  const context = {stdout: t.context.stdout, stderr: t.context.stderr, logger: t.context.logger};
 
   const result = await generateNotes(pluginConfig, context);
   t.is(result, 'Release note');
@@ -24,7 +24,7 @@ test('Return the value generateNotes script wrote to stdout', async t => {
 
 test('Throw "Error" if if the generateNotes script does not returns 0', async t => {
   const pluginConfig = {cmd: 'exit 1'};
-  const context = {logger: t.context.logger};
+  const context = {stdout: t.context.stdout, stderr: t.context.stderr, logger: t.context.logger};
 
   await t.throws(generateNotes(pluginConfig, context), Error);
 });

--- a/test/prepare.test.js
+++ b/test/prepare.test.js
@@ -1,11 +1,11 @@
 import test from 'ava';
 import {stub} from 'sinon';
+import {WritableStreamBuffer} from 'stream-buffers';
 import {prepare} from '..';
 
-stub(process.stdout, 'write');
-stub(process.stderr, 'write');
-
 test.beforeEach(t => {
+  t.context.stdout = new WritableStreamBuffer();
+  t.context.stderr = new WritableStreamBuffer();
   // Mock logger
   t.context.log = stub();
   t.context.error = stub();
@@ -14,14 +14,14 @@ test.beforeEach(t => {
 
 test('Execute script in prepare step', async t => {
   const pluginConfig = {cmd: './test/fixtures/echo-args.sh'};
-  const context = {logger: t.context.logger};
+  const context = {stdout: t.context.stdout, stderr: t.context.stderr, logger: t.context.logger};
 
   await t.notThrows(prepare(pluginConfig, context));
 });
 
 test('Throw "Error" if the prepare script does not returns 0', async t => {
   const pluginConfig = {cmd: 'exit 1'};
-  const context = {logger: t.context.logger};
+  const context = {stdout: t.context.stdout, stderr: t.context.stderr, logger: t.context.logger};
 
   await t.throws(prepare(pluginConfig, context), Error);
 });

--- a/test/publish.test.js
+++ b/test/publish.test.js
@@ -1,12 +1,11 @@
 import test from 'ava';
 import {stub} from 'sinon';
+import {WritableStreamBuffer} from 'stream-buffers';
 import {publish} from '..';
 
-// Disable logs during tests
-stub(process.stdout, 'write');
-stub(process.stderr, 'write');
-
 test.beforeEach(t => {
+  t.context.stdout = new WritableStreamBuffer();
+  t.context.stderr = new WritableStreamBuffer();
   // Mock logger
   t.context.log = stub();
   t.context.error = stub();
@@ -18,7 +17,7 @@ test('Parse JSON returned by publish script', async t => {
     cmd:
       './test/fixtures/echo-args.sh {\\"name\\": \\"Release name\\", \\"url\\": \\"https://host.com/release/1.0.0\\"}',
   };
-  const context = {logger: t.context.logger};
+  const context = {stdout: t.context.stdout, stderr: t.context.stderr, logger: t.context.logger};
 
   const result = await publish(pluginConfig, context);
   t.deepEqual(result, {name: 'Release name', url: 'https://host.com/release/1.0.0'});
@@ -28,7 +27,7 @@ test('Return "undefined" if the publish script wrtite invalid JSON to stdout', a
   const pluginConfig = {
     cmd: './test/fixtures/echo-args.sh invalid_json',
   };
-  const context = {logger: t.context.logger};
+  const context = {stdout: t.context.stdout, stderr: t.context.stderr, logger: t.context.logger};
 
   const result = await publish(pluginConfig, context);
   t.is(result, undefined);
@@ -38,7 +37,7 @@ test('Return "undefined" if the publish script wrtite nothing to stdout', async 
   const pluginConfig = {
     cmd: './test/fixtures/echo-args.sh',
   };
-  const context = {logger: t.context.logger};
+  const context = {stdout: t.context.stdout, stderr: t.context.stderr, logger: t.context.logger};
 
   const result = await publish(pluginConfig, context);
   t.is(result, undefined);
@@ -46,7 +45,7 @@ test('Return "undefined" if the publish script wrtite nothing to stdout', async 
 
 test('Throw "Error" if the publish script does not returns 0', async t => {
   const pluginConfig = {cmd: 'exit 1'};
-  const context = {logger: t.context.logger, options: {}};
+  const context = {stdout: t.context.stdout, stderr: t.context.stderr, logger: t.context.logger, options: {}};
 
   await t.throws(publish(pluginConfig, context), Error);
 });

--- a/test/success.test.js
+++ b/test/success.test.js
@@ -1,11 +1,11 @@
 import test from 'ava';
 import {stub} from 'sinon';
+import {WritableStreamBuffer} from 'stream-buffers';
 import {success} from '..';
 
-stub(process.stdout, 'write');
-stub(process.stderr, 'write');
-
 test.beforeEach(t => {
+  t.context.stdout = new WritableStreamBuffer();
+  t.context.stderr = new WritableStreamBuffer();
   // Mock logger
   t.context.log = stub();
   t.context.error = stub();
@@ -14,14 +14,14 @@ test.beforeEach(t => {
 
 test('Execute script in success step', async t => {
   const pluginConfig = {cmd: './test/fixtures/echo-args.sh'};
-  const context = {logger: t.context.logger};
+  const context = {stdout: t.context.stdout, stderr: t.context.stderr, logger: t.context.logger};
 
   await t.notThrows(success(pluginConfig, context));
 });
 
 test('Throw "Error" if the success script does not returns 0', async t => {
   const pluginConfig = {cmd: 'exit 1'};
-  const context = {logger: t.context.logger};
+  const context = {stdout: t.context.stdout, stderr: t.context.stderr, logger: t.context.logger};
 
   await t.throws(success(pluginConfig, context), Error);
 });

--- a/test/verify-confitions.test.js
+++ b/test/verify-confitions.test.js
@@ -1,12 +1,11 @@
 import test from 'ava';
 import {stub} from 'sinon';
+import {WritableStreamBuffer} from 'stream-buffers';
 import {verifyConditions} from '..';
 
-// Disable logs during tests
-stub(process.stdout, 'write');
-stub(process.stderr, 'write');
-
 test.beforeEach(t => {
+  t.context.stdout = new WritableStreamBuffer();
+  t.context.stderr = new WritableStreamBuffer();
   // Mock logger
   t.context.log = stub();
   t.context.error = stub();
@@ -15,14 +14,14 @@ test.beforeEach(t => {
 
 test('Verify plugin config is an Object with a "cmd" property', async t => {
   const pluginConfig = {cmd: './test/fixtures/echo-args.sh'};
-  const context = {logger: t.context.logger};
+  const context = {stdout: t.context.stdout, stderr: t.context.stderr, logger: t.context.logger};
 
   await t.notThrows(verifyConditions(pluginConfig, context));
 });
 
 test('Throw "SemanticReleaseError" if "cmd" options is missing', async t => {
   const pluginConfig = {};
-  const context = {logger: t.context.logger};
+  const context = {stdout: t.context.stdout, stderr: t.context.stderr, logger: t.context.logger};
 
   const error = await t.throws(verifyConditions(pluginConfig, context));
 
@@ -32,7 +31,7 @@ test('Throw "SemanticReleaseError" if "cmd" options is missing', async t => {
 
 test('Throw "SemanticReleaseError" if "cmd" options is empty', async t => {
   const pluginConfig = {cmd: '      '};
-  const context = {logger: t.context.logger, options: {}};
+  const context = {stdout: t.context.stdout, stderr: t.context.stderr, logger: t.context.logger, options: {}};
 
   const error = await t.throws(verifyConditions(pluginConfig, context));
 
@@ -43,6 +42,8 @@ test('Throw "SemanticReleaseError" if "cmd" options is empty', async t => {
 test('Throw "SemanticReleaseError" if another exec plugin "cmd" options is missing', async t => {
   const pluginConfig = {cmd: './test/fixtures/echo-args.sh'};
   const context = {
+    stdout: t.context.stdout,
+    stderr: t.context.stderr,
     logger: t.context.logger,
     options: {publish: ['@semantic-release/npm', {path: '@semantic-release/exec'}]},
   };
@@ -56,6 +57,8 @@ test('Throw "SemanticReleaseError" if another exec plugin "cmd" options is missi
 test('Throw "SemanticReleaseError" if another exec plugin "cmd" options is empty', async t => {
   const pluginConfig = {cmd: './test/fixtures/echo-args.sh'};
   const context = {
+    stdout: t.context.stdout,
+    stderr: t.context.stderr,
     logger: t.context.logger,
     options: {
       branch: 'master',
@@ -71,14 +74,14 @@ test('Throw "SemanticReleaseError" if another exec plugin "cmd" options is empty
 
 test('Return if the verifyConditions script returns 0', async t => {
   const pluginConfig = {cmd: 'exit 0'};
-  const context = {logger: t.context.logger, options: {}};
+  const context = {stdout: t.context.stdout, stderr: t.context.stderr, logger: t.context.logger, options: {}};
 
   await t.notThrows(verifyConditions(pluginConfig, context));
 });
 
 test('Throw "SemanticReleaseError" if the verifyConditions script does not returns 0', async t => {
   const pluginConfig = {cmd: 'exit 1'};
-  const context = {logger: t.context.logger, options: {}};
+  const context = {stdout: t.context.stdout, stderr: t.context.stderr, logger: t.context.logger, options: {}};
 
   const error = await t.throws(verifyConditions(pluginConfig, context));
 

--- a/test/verify-release.test.js
+++ b/test/verify-release.test.js
@@ -1,12 +1,11 @@
 import test from 'ava';
 import {stub} from 'sinon';
+import {WritableStreamBuffer} from 'stream-buffers';
 import {verifyRelease} from '..';
 
-// Disable logs during tests
-stub(process.stdout, 'write');
-stub(process.stderr, 'write');
-
 test.beforeEach(t => {
+  t.context.stdout = new WritableStreamBuffer();
+  t.context.stderr = new WritableStreamBuffer();
   // Mock logger
   t.context.log = stub();
   t.context.error = stub();
@@ -15,14 +14,14 @@ test.beforeEach(t => {
 
 test('Return if the verifyRelease script returns 0', async t => {
   const pluginConfig = {cmd: 'exit 0'};
-  const context = {logger: t.context.logger, options: {}};
+  const context = {stdout: t.context.stdout, stderr: t.context.stderr, logger: t.context.logger, options: {}};
 
   await t.notThrows(verifyRelease(pluginConfig, context));
 });
 
 test('Throw "SemanticReleaseError" if the verifyRelease script does not returns 0', async t => {
   const pluginConfig = {cmd: 'exit 1'};
-  const context = {logger: t.context.logger, options: {}};
+  const context = {stdout: t.context.stdout, stderr: t.context.stderr, logger: t.context.logger, options: {}};
 
   const error = await t.throws(verifyRelease(pluginConfig, context));
 


### PR DESCRIPTION
BREAKING CHANGE: require `semantic-release` >= `15.9.0`