### PR TITLE
fix: throw error if .cmd is not present

### DIFF
--- a/lib/exec-script.js
+++ b/lib/exec-script.js
@@ -1,7 +1,12 @@
 const {template} = require('lodash');
 const execa = require('execa');
+const verifyConfig = require('./verify-config');
 
-module.exports = async ({cmd, ...config}, {cwd, env, stdout, stderr, logger, ...context}) => {
+module.exports = async (cfg, {cwd, env, stdout, stderr, logger, ...context}) => {
+  // so that if cfg.cmd is not present - error is thrown
+  verifyConfig(cfg);
+
+  const {cmd, ...config} = cfg;
   const script = template(cmd)({config, ...context});
 
   logger.log('Call script %s', script);


### PR DESCRIPTION
NOTE: my build was silently skipping prepare step where I accidentally wrote "command" instead of "cmd"