### PR TITLE
fix: verify the `cmd` config independently for each steps

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,26 +1,10 @@
-const {castArray, isPlainObject} = require('lodash');
 const parseJson = require('parse-json');
 const debug = require('debug')('semantic-release:exec');
 const SemanticReleaseError = require('@semantic-release/error');
 const execScript = require('./lib/exec-script');
 const verifyConfig = require('./lib/verify-config');
 
-const PLUGIN_TYPES = ['analyzeCommits', 'verifyRelease', 'generateNotes', 'publish', 'success', 'fail'];
-
 async function verifyConditions(pluginConfig, context) {
-  for (const [option, value] of Object.entries(context.options || {})) {
-    if (PLUGIN_TYPES.includes(option)) {
-      for (const plugin of castArray(value)) {
-        if (
-          plugin === '@semantic-release/exec' ||
-          (isPlainObject(plugin) && plugin.path === '@semantic-release/exec')
-        ) {
-          verifyConfig(plugin);
-        }
-      }
-    }
-  }
-
   verifyConfig(pluginConfig);
 
   try {
@@ -31,11 +15,15 @@ async function verifyConditions(pluginConfig, context) {
 }
 
 async function analyzeCommits(pluginConfig, context) {
+  verifyConfig(pluginConfig);
+
   const stdout = await execScript(pluginConfig, context);
   return stdout.trim() ? stdout : undefined;
 }
 
 async function verifyRelease(pluginConfig, context) {
+  verifyConfig(pluginConfig);
+
   try {
     await execScript(pluginConfig, context);
   } catch (err) {
@@ -44,15 +32,22 @@ async function verifyRelease(pluginConfig, context) {
 }
 
 async function generateNotes(pluginConfig, context) {
+  verifyConfig(pluginConfig);
+
   return execScript(pluginConfig, context);
 }
 
 async function prepare(pluginConfig, context) {
+  verifyConfig(pluginConfig);
+
   await execScript(pluginConfig, context);
 }
 
 async function publish(pluginConfig, context) {
+  verifyConfig(pluginConfig);
+
   const stdout = await execScript(pluginConfig, context);
+
   try {
     return stdout.trim() ? parseJson(stdout) : undefined;
   } catch (err) {
@@ -65,10 +60,14 @@ async function publish(pluginConfig, context) {
 }
 
 async function success(pluginConfig, context) {
+  verifyConfig(pluginConfig);
+
   await execScript(pluginConfig, context);
 }
 
 async function fail(pluginConfig, context) {
+  verifyConfig(pluginConfig);
+
   await execScript(pluginConfig, context);
 }
 

--- a/test/analyze-commits.test.js
+++ b/test/analyze-commits.test.js
@@ -32,6 +32,26 @@ test('Return "undefined" if the analyzeCommits script wrtite nothing to stdout',
   t.is(result, undefined);
 });
 
+test('Throw "SemanticReleaseError" if "cmd" options is missing', async t => {
+  const pluginConfig = {};
+  const context = {stdout: t.context.stdout, stderr: t.context.stderr, logger: t.context.logger};
+
+  const error = await t.throws(analyzeCommits(pluginConfig, context));
+
+  t.is(error.name, 'SemanticReleaseError');
+  t.is(error.code, 'EINVALIDCMD');
+});
+
+test('Throw "SemanticReleaseError" if "cmd" options is empty', async t => {
+  const pluginConfig = {cmd: '      '};
+  const context = {stdout: t.context.stdout, stderr: t.context.stderr, logger: t.context.logger, options: {}};
+
+  const error = await t.throws(analyzeCommits(pluginConfig, context));
+
+  t.is(error.name, 'SemanticReleaseError');
+  t.is(error.code, 'EINVALIDCMD');
+});
+
 test('Throw Error if if the analyzeCommits script does not returns 0', async t => {
   const pluginConfig = {cmd: 'exit 1'};
   const context = {stdout: t.context.stdout, stderr: t.context.stderr, logger: t.context.logger};

--- a/test/fail.test.js
+++ b/test/fail.test.js
@@ -19,6 +19,26 @@ test('Execute script in fail step', async t => {
   await t.notThrows(fail(pluginConfig, context));
 });
 
+test('Throw "SemanticReleaseError" if "cmd" options is missing', async t => {
+  const pluginConfig = {};
+  const context = {stdout: t.context.stdout, stderr: t.context.stderr, logger: t.context.logger};
+
+  const error = await t.throws(fail(pluginConfig, context));
+
+  t.is(error.name, 'SemanticReleaseError');
+  t.is(error.code, 'EINVALIDCMD');
+});
+
+test('Throw "SemanticReleaseError" if "cmd" options is empty', async t => {
+  const pluginConfig = {cmd: '      '};
+  const context = {stdout: t.context.stdout, stderr: t.context.stderr, logger: t.context.logger, options: {}};
+
+  const error = await t.throws(fail(pluginConfig, context));
+
+  t.is(error.name, 'SemanticReleaseError');
+  t.is(error.code, 'EINVALIDCMD');
+});
+
 test('Throw "Error" if the fail script does not returns 0', async t => {
   const pluginConfig = {cmd: 'exit 1'};
   const context = {stdout: t.context.stdout, stderr: t.context.stderr, logger: t.context.logger};

--- a/test/generate-notes.test.js
+++ b/test/generate-notes.test.js
@@ -22,6 +22,26 @@ test('Return the value generateNotes script wrote to stdout', async t => {
   t.is(result, 'Release note');
 });
 
+test('Throw "SemanticReleaseError" if "cmd" options is missing', async t => {
+  const pluginConfig = {};
+  const context = {stdout: t.context.stdout, stderr: t.context.stderr, logger: t.context.logger};
+
+  const error = await t.throws(generateNotes(pluginConfig, context));
+
+  t.is(error.name, 'SemanticReleaseError');
+  t.is(error.code, 'EINVALIDCMD');
+});
+
+test('Throw "SemanticReleaseError" if "cmd" options is empty', async t => {
+  const pluginConfig = {cmd: '      '};
+  const context = {stdout: t.context.stdout, stderr: t.context.stderr, logger: t.context.logger, options: {}};
+
+  const error = await t.throws(generateNotes(pluginConfig, context));
+
+  t.is(error.name, 'SemanticReleaseError');
+  t.is(error.code, 'EINVALIDCMD');
+});
+
 test('Throw "Error" if if the generateNotes script does not returns 0', async t => {
   const pluginConfig = {cmd: 'exit 1'};
   const context = {stdout: t.context.stdout, stderr: t.context.stderr, logger: t.context.logger};

--- a/test/prepare.test.js
+++ b/test/prepare.test.js
@@ -19,6 +19,26 @@ test('Execute script in prepare step', async t => {
   await t.notThrows(prepare(pluginConfig, context));
 });
 
+test('Throw "SemanticReleaseError" if "cmd" options is missing', async t => {
+  const pluginConfig = {};
+  const context = {stdout: t.context.stdout, stderr: t.context.stderr, logger: t.context.logger};
+
+  const error = await t.throws(prepare(pluginConfig, context));
+
+  t.is(error.name, 'SemanticReleaseError');
+  t.is(error.code, 'EINVALIDCMD');
+});
+
+test('Throw "SemanticReleaseError" if "cmd" options is empty', async t => {
+  const pluginConfig = {cmd: '      '};
+  const context = {stdout: t.context.stdout, stderr: t.context.stderr, logger: t.context.logger, options: {}};
+
+  const error = await t.throws(prepare(pluginConfig, context));
+
+  t.is(error.name, 'SemanticReleaseError');
+  t.is(error.code, 'EINVALIDCMD');
+});
+
 test('Throw "Error" if the prepare script does not returns 0', async t => {
   const pluginConfig = {cmd: 'exit 1'};
   const context = {stdout: t.context.stdout, stderr: t.context.stderr, logger: t.context.logger};

--- a/test/publish.test.js
+++ b/test/publish.test.js
@@ -43,6 +43,26 @@ test('Return "undefined" if the publish script wrtite nothing to stdout', async 
   t.is(result, undefined);
 });
 
+test('Throw "SemanticReleaseError" if "cmd" options is missing', async t => {
+  const pluginConfig = {};
+  const context = {stdout: t.context.stdout, stderr: t.context.stderr, logger: t.context.logger};
+
+  const error = await t.throws(publish(pluginConfig, context));
+
+  t.is(error.name, 'SemanticReleaseError');
+  t.is(error.code, 'EINVALIDCMD');
+});
+
+test('Throw "SemanticReleaseError" if "cmd" options is empty', async t => {
+  const pluginConfig = {cmd: '      '};
+  const context = {stdout: t.context.stdout, stderr: t.context.stderr, logger: t.context.logger, options: {}};
+
+  const error = await t.throws(publish(pluginConfig, context));
+
+  t.is(error.name, 'SemanticReleaseError');
+  t.is(error.code, 'EINVALIDCMD');
+});
+
 test('Throw "Error" if the publish script does not returns 0', async t => {
   const pluginConfig = {cmd: 'exit 1'};
   const context = {stdout: t.context.stdout, stderr: t.context.stderr, logger: t.context.logger, options: {}};

--- a/test/success.test.js
+++ b/test/success.test.js
@@ -19,6 +19,26 @@ test('Execute script in success step', async t => {
   await t.notThrows(success(pluginConfig, context));
 });
 
+test('Throw "SemanticReleaseError" if "cmd" options is missing', async t => {
+  const pluginConfig = {};
+  const context = {stdout: t.context.stdout, stderr: t.context.stderr, logger: t.context.logger};
+
+  const error = await t.throws(success(pluginConfig, context));
+
+  t.is(error.name, 'SemanticReleaseError');
+  t.is(error.code, 'EINVALIDCMD');
+});
+
+test('Throw "SemanticReleaseError" if "cmd" options is empty', async t => {
+  const pluginConfig = {cmd: '      '};
+  const context = {stdout: t.context.stdout, stderr: t.context.stderr, logger: t.context.logger, options: {}};
+
+  const error = await t.throws(success(pluginConfig, context));
+
+  t.is(error.name, 'SemanticReleaseError');
+  t.is(error.code, 'EINVALIDCMD');
+});
+
 test('Throw "Error" if the success script does not returns 0', async t => {
   const pluginConfig = {cmd: 'exit 1'};
   const context = {stdout: t.context.stdout, stderr: t.context.stderr, logger: t.context.logger};

--- a/test/verify-confitions.test.js
+++ b/test/verify-confitions.test.js
@@ -39,39 +39,6 @@ test('Throw "SemanticReleaseError" if "cmd" options is empty', async t => {
   t.is(error.code, 'EINVALIDCMD');
 });
 
-test('Throw "SemanticReleaseError" if another exec plugin "cmd" options is missing', async t => {
-  const pluginConfig = {cmd: './test/fixtures/echo-args.sh'};
-  const context = {
-    stdout: t.context.stdout,
-    stderr: t.context.stderr,
-    logger: t.context.logger,
-    options: {publish: ['@semantic-release/npm', {path: '@semantic-release/exec'}]},
-  };
-
-  const error = await t.throws(verifyConditions(pluginConfig, context));
-
-  t.is(error.name, 'SemanticReleaseError');
-  t.is(error.code, 'EINVALIDCMD');
-});
-
-test('Throw "SemanticReleaseError" if another exec plugin "cmd" options is empty', async t => {
-  const pluginConfig = {cmd: './test/fixtures/echo-args.sh'};
-  const context = {
-    stdout: t.context.stdout,
-    stderr: t.context.stderr,
-    logger: t.context.logger,
-    options: {
-      branch: 'master',
-      publish: ['@semantic-release/npm', {path: '@semantic-release/exec', cmd: '  '}],
-    },
-  };
-
-  const error = await t.throws(verifyConditions(pluginConfig, context));
-
-  t.is(error.name, 'SemanticReleaseError');
-  t.is(error.code, 'EINVALIDCMD');
-});
-
 test('Return if the verifyConditions script returns 0', async t => {
   const pluginConfig = {cmd: 'exit 0'};
   const context = {stdout: t.context.stdout, stderr: t.context.stderr, logger: t.context.logger, options: {}};

--- a/test/verify-release.test.js
+++ b/test/verify-release.test.js
@@ -19,6 +19,26 @@ test('Return if the verifyRelease script returns 0', async t => {
   await t.notThrows(verifyRelease(pluginConfig, context));
 });
 
+test('Throw "SemanticReleaseError" if "cmd" options is missing', async t => {
+  const pluginConfig = {};
+  const context = {stdout: t.context.stdout, stderr: t.context.stderr, logger: t.context.logger};
+
+  const error = await t.throws(verifyRelease(pluginConfig, context));
+
+  t.is(error.name, 'SemanticReleaseError');
+  t.is(error.code, 'EINVALIDCMD');
+});
+
+test('Throw "SemanticReleaseError" if "cmd" options is empty', async t => {
+  const pluginConfig = {cmd: '      '};
+  const context = {stdout: t.context.stdout, stderr: t.context.stderr, logger: t.context.logger, options: {}};
+
+  const error = await t.throws(verifyRelease(pluginConfig, context));
+
+  t.is(error.name, 'SemanticReleaseError');
+  t.is(error.code, 'EINVALIDCMD');
+});
+
 test('Throw "SemanticReleaseError" if the verifyRelease script does not returns 0', async t => {
   const pluginConfig = {cmd: 'exit 1'};
   const context = {stdout: t.context.stdout, stderr: t.context.stderr, logger: t.context.logger, options: {}};


### PR DESCRIPTION
Fix #35