### PR TITLE
docs: add note about using nextRelease.notes vs changelog plugin

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,7 +44,9 @@ With this example:
 - the shell command `./verify.sh` will be executed on the [verify conditions step](https://github.com/semantic-release/semantic-release#release-steps)
 - the shell command `./publish.sh 1.0.0 master 3 870668040000` (for the release of version `1.0.0` from branch `master` with `3` commits on `August 4th, 1997 at 2:14 AM`) will be executed on the [publish step](https://github.com/semantic-release/semantic-release#release-steps)
 
-**Note**: it's required to define a plugin for the [analyze commits step](https://github.com/semantic-release/semantic-release#release-steps). If no [analyzeCommitsCmd](#analyzecommitscmd) is defined the plugin [@semantic-release/commit-analyzer](https://github.com/semantic-release/commit-analyzer) must be defined in the `plugins` list.
+### Notes
+* It's required to define a plugin for the [analyze commits step](https://github.com/semantic-release/semantic-release#release-steps). If no [analyzeCommitsCmd](#analyzecommitscmd) is defined the plugin [@semantic-release/commit-analyzer](https://github.com/semantic-release/commit-analyzer) must be defined in the `plugins` list.
+* Using `${nextRelease.notes}` will resolve. However, in order to avoid issues when the changelog exceeds the character limit of your shell, it is recommended to use the [@semantic-release/changelog](https://github.com/semantic-release/changelog) plugin instead. 
 
 ## Configuration
 


### PR DESCRIPTION
I was running into issues on Windows (no my choice) where the command would error when `nextRelease.notes` expanded into too many characters. Wish I had known about the changelog plugin ahead of time. 