### PR TITLE
docs: update README.md plugins context link

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,7 +64,7 @@ With this example:
 | `shell`               | The shell to use to run the command. See [execa#shell](https://github.com/sindresorhus/execa#shell).                                                                                                                                                                                                                                     |
 | `execCwd`             | The path to use as current working directory when executing the shell commands. This path is relative to the path from which **semantic-release** is running. For example if **semantic-release** runs from `/my-project` and `execCwd` is set to `buildScripts` then the shell command will be executed from `/my-project/buildScripts` |
 
-Each shell command is generated with [Lodash template](https://lodash.com/docs#template). All the objects passed to the [semantic-release plugins](https://github.com/semantic-release/semantic-release#plugins) are available as template options.
+Each shell command is generated with [Lodash template](https://lodash.com/docs#template). All the [`context` object keys](https://github.com/semantic-release/semantic-release/blob/master/docs/developer-guide/plugin.md#context) passed to semantic-release plugins are available as template options.
 
 ## verifyConditionsCmd
 


### PR DESCRIPTION
Existing link doesn't point to anywhere specifically in `semantic-release`'s README.md. Also the intent is to point to plugin context that can be used in templates. So pointing there specifically. Rephrases a bit for that purpose.