### PR TITLE
Print more useful error for non-process failure

### DIFF
--- a/index.js
+++ b/index.js
@@ -7,6 +7,12 @@ import verifyConfig from "./lib/verify-config.js";
 
 const debug = debugFactory("semantic-release:exec");
 
+function execErrorMessage(error) {
+  return error.stdout && error.stdout.trim.length > 0
+    ? error.stdout
+    : `${error.name}: ${error.message}`;
+}
+
 export async function verifyConditions(pluginConfig, context) {
   if (!isNil(pluginConfig.verifyConditionsCmd) || !isNil(pluginConfig.cmd)) {
     verifyConfig("verifyConditionsCmd", pluginConfig);
@@ -14,7 +20,8 @@ export async function verifyConditions(pluginConfig, context) {
     try {
       await exec("verifyConditionsCmd", pluginConfig, context);
     } catch (error) {
-      throw new SemanticReleaseError(error.stdout, "EVERIFYCONDITIONS");
+      const message = execErrorMessage(error);
+      throw new SemanticReleaseError(message, "EVERIFYCONDITIONS");
     }
   }
 }
@@ -35,7 +42,8 @@ export async function verifyRelease(pluginConfig, context) {
     try {
       await exec("verifyReleaseCmd", pluginConfig, context);
     } catch (error) {
-      throw new SemanticReleaseError(error.stdout, "EVERIFYRELEASE");
+      const message = execErrorMessage(error);
+      throw new SemanticReleaseError(message, "EVERIFYRELEASE");
     }
   }
 }

--- a/test/integration.test.js
+++ b/test/integration.test.js
@@ -22,3 +22,20 @@ test('Skip step if neither "cmd" nor step cmd is defined', async (t) => {
   await t.notThrowsAsync(success({}, {}));
   await t.notThrowsAsync(fail({}, {}));
 });
+
+const assertReferenceError = test.macro(async (t, fn) => {
+  const err = await t.throwsAsync(fn({ cmd: "echo ${iDont.exist}" }, {}));
+  t.regex(err.message, /iDont is not defined/);
+});
+
+test(
+  "Throws a useful error for bad interpolation in verifyConditions",
+  assertReferenceError,
+  verifyConditions,
+);
+
+test(
+  "Throws a useful error for bad interpolation in verifyRelease",
+  assertReferenceError,
+  verifyRelease,
+);


### PR DESCRIPTION
`error.stdout` will be empty if the error was not actually the result of
the executed process failing (such as interpolation errors), we should
include more detail for that case.

Fixes #447.
