### PR TITLE
chore(ci): update Node.js engine version and test matrix

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -13,9 +13,9 @@ jobs:
     strategy:
       matrix:
         node-version:
-          - 20.8.1
-          - 20
-          - 22
+          - 22.22.2
+          - 24.15
+          - 24
         os:
           - ubuntu-latest
           - macos-latest

--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
     "stream-buffers": "3.0.3"
   },
   "engines": {
-    "node": ">=20.8.1"
+    "node": "^22.22.2 || >=24.15"
   },
   "files": [
     "lib",


### PR DESCRIPTION
This pull request updates the Node.js versions used in both the GitHub Actions workflow and the `package.json` engines field to ensure compatibility with the latest Node.js releases.

**Node.js version updates:**

* Updated the Node.js matrix in `.github/workflows/test.yml` to test against `22.22.2`, `24.15`, and `24`, replacing the previous versions (`20.8.1`, `20`, and `22`).
* Updated the `node` engines field in `package.json` to require `^22.22.2` or `>=24.15`, ensuring the package is only installed with compatible Node.js versions.

BREAKING CHANGE: Now require Node.js `^22.22.2` or `>=24.15`